### PR TITLE
Build smartmontools from source (More updated version), and updated check.sh script

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,32 @@
 FROM alpine:latest
-RUN apk add --no-cache smartmontools
 
+# Install build dependencies
+RUN apk add --no-cache \
+    subversion \
+    automake \
+    autoconf \
+    build-base \
+    libtool \
+    linux-headers \
+    pciutils-dev \
+    libcap-ng-dev \
+    bash
+
+# Get the source
+RUN svn co https://svn.code.sf.net/p/smartmontools/code/trunk/smartmontools /opt/smartmontools
+
+# Run autogen.sh
+RUN cd /opt/smartmontools && \
+    ./autogen.sh && \
+    ./configure && \
+    make -j$(nproc) && \
+    make install
+
+# Add the 'check.sh' script
 COPY check.sh /entrypoint.sh
+
+# Make sure it's executable
 RUN chmod +x /entrypoint.sh
 
+# Run it
 ENTRYPOINT ["/entrypoint.sh"]

--- a/check.sh
+++ b/check.sh
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 
+colors=(
+    "\e[0m"  # 0 - Reset
+    "\e[31m" # 1 - Red
+    "\e[32m" # 2 - Green
+)
+
 if [[ ${#} -eq 0 ]]; then
     echo "Usage: $0 <block_device> [block_device2 ...]"
     echo "       Use ALL to automatically check all block devices"
@@ -70,9 +76,9 @@ function check_device {
     abs_diff=${diff#-}  # Remove negative sign
     
     if [[ "${abs_diff}" -le "1" ]]; then
-        echo "Device check:        PASS"
+        echo -e "Device check:         ${colors[2]}PASS${colors[0]}"
     else
-        echo "Device check:        FAIL"
+        echo -e "Device check:         ${colors[1]}FAIL${colors[0]}"
     fi
     echo
 }

--- a/check.sh
+++ b/check.sh
@@ -1,6 +1,6 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
-if [ $# -eq 0 ]; then
+if [[ ${#} -eq 0 ]]; then
     echo "Usage: $0 <block_device> [block_device2 ...]"
     echo "       Use ALL to automatically check all block devices"
     exit 1
@@ -11,77 +11,114 @@ if ! command -v smartctl &> /dev/null; then
     exit 1
 fi
 
-check_device() {
-    local DEVICE=$1
+function check_vendor {
+    local device="${1}"
     
     # Skip if device doesn't exist
-    if [ ! -e "$DEVICE" ]; then
-        return
+    if [[ ! -e "${device}" ]]; then
+        return 1
     fi
     
     # Skip if not a block device
-    if [ ! -b "$DEVICE" ]; then
-        return
+    if [[ ! -b "${device}" ]]; then
+        return 1
     fi
     
-    echo "=== Checking device: $DEVICE ==="
+    vendor="$(<"/sys/block/${device##*/}/device/vendor")"
+    vendor="${vendor// /}"
+    if ! [[ "${vendor}" == "SEAGATE" ]]; then
+        echo "Device [${device}] does not appear to be a Seagate drive"
+        return 1
+    fi
+}
+
+function check_device {
+    local device="${1}"
     
-    SMART_HOURS=$(smartctl -a "$DEVICE" | awk '/Power_On_Hours/{print $10}' | head -n 1)
-    FARM_HOURS=$(smartctl -l farm "$DEVICE" | awk '/Power on Hours:/{print $4}' | head -n 1)
+    echo "=== Checking device: ${device} ==="
     
+    while read -r smart_hours; do
+        if [[ "${smart_hours}" =~ ^.*"Accumulated power on time, hours:minutes".*$ ]]; then
+            smart_hours="${smart_hours##* }"
+            smart_hours="${smart_hours%:*}"
+            break
+        fi
+    done < <(smartctl -a "${device}")
+    while read -r farm_hours; do
+        if [[ "${farm_hours}" =~ ^.*"Power on Hour".*$ ]]; then
+            farm_hours="${farm_hours##* }"
+            break
+        fi
+    done < <(smartctl -l farm "${device}")
+    
+    # Check if SMART hours are available
+    if [[ -z "${smart_hours}" ]]; then
+        echo "Unable to retrieve SMART hours for device [${device}]"
+        return 0
+    fi
     # Check if FARM hours are available
-    if [ -z "$FARM_HOURS" ]; then
-        echo "FARM data not available - likely not a Seagate drive"
-        echo "SMART: $SMART_HOURS"
-        echo "FARM: N/A"
-        echo "RESULT: SKIP"
-        echo
-        return
+    if [[ -z "${farm_hours}" ]]; then
+        echo "Unable to retrieve FARM hours for device [${device}]"
+        return 0
     fi
     
-    echo "SMART: $SMART_HOURS"
-    echo "FARM: $FARM_HOURS"
+    echo "SMART hours reported: ${smart_hours}"
+    echo "FARM hours reported:  ${farm_hours}"
     
     # Calculate absolute difference
-    DIFF=$(( SMART_HOURS - FARM_HOURS ))
-    ABS_DIFF=${DIFF#-}  # Remove negative sign
+    diff=$(( smart_hours - farm_hours ))
+    abs_diff=${diff#-}  # Remove negative sign
     
-    if [ $ABS_DIFF -le 1 ]; then
-        echo "RESULT: PASS"
+    if [[ "${abs_diff}" -le "1" ]]; then
+        echo "Device check:        PASS"
     else
-        echo "RESULT: FAIL"
+        echo "Device check:        FAIL"
     fi
     echo
 }
 
 # Handle ALL case
-if [ "$1" = "ALL" ]; then
+if [[ "${1^^}" = "ALL" ]]; then
     # /dev/sd* block devices
     for device in /dev/sd*; do
         # Skip partition devices (e.g., /dev/sda1)
-        if ! echo "$device" | grep -q '[0-9]$'; then
-            check_device "$device"
+        if [[ "${device}" =~ /dev/sd[a-z]$ ]]; then
+            if check_vendor "${device}"; then
+                list+=("${device}")
+            fi
         fi
     done
 
     # Synology /dev/sata* block devices
     for device in /dev/sata*; do
         # Skip partition devices (e.g., /dev/sata1p1)
-        if echo "$device" | grep -q -E 'sata[0-9][0-9]?[0-9]?$'; then
-            check_device "$device"
+        if [[ "${device}" =~ ^/dev/sata[0-9]+$ ]]; then
+            if check_vendor "${device}"; then
+                list+=("${device}")
+            fi
         fi
     done
 
     # Synology /dev/sas* block devices
     for device in /dev/sas*; do
         # Skip partition devices (e.g., /dev/sas1p1)
-        if echo "$device" | grep -q -E 'sas[0-9][0-9]?[0-9]?$'; then
-            check_device "$device"
+        if [[ "${device}"  =~ ^/dev/sas[0-9]+$ ]]; then
+            if check_vendor "${device}"; then
+                list+=("${device}")
+            fi
         fi
     done
 else
     # Handle explicit device arguments
-    for device in "$@"; do
-        check_device "$device"
+    for device in "${@}"; do
+        if check_vendor "${device}"; then
+            list+=("${device}")
+        fi
     done
 fi
+
+for device in "${list[@]}"; do
+    check_device "${device}"
+done
+
+exit 0


### PR DESCRIPTION
Debian is not exactly known for keeping the most up-to-date packages, and the `smartctl` provided by `apt` does not have support for the `-l farm` parameter.

The updated Dockerfile will instead pull the most recent copy of the source and build it. Additionally, the `check.sh` script was not detected any of the hours (SMART or FARM) on my SAS drives. I tweaked it so that it now does, along with some other QoL changes (and switched it from `sh` to `bash`).

Note that my updated version of `check.sh` requires the volume bind mount `-v /sys:/sys`, in addition to `-v /dev:/dev`, so that it can programmatically obtain the drive vendor to confirm it's a Seagate drive. I think these bind mounts can be mounted as read only, but haven't tested that myself.